### PR TITLE
Use the CuratorFramework's supplied ThreadFactory in ConnectionStateManager

### DIFF
--- a/curator-framework/src/main/java/com/netflix/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/com/netflix/curator/framework/imps/CuratorFrameworkImpl.java
@@ -122,7 +122,7 @@ public class CuratorFrameworkImpl implements CuratorFramework
         namespace = builder.getNamespace();
         ensurePath = (namespace != null) ? new EnsurePath(ZKPaths.makePath("/", namespace)) : null;
         executorService = Executors.newFixedThreadPool(2, builder.getThreadFactory());  // 1 for listeners, 1 for background ops
-        connectionStateManager = new ConnectionStateManager(this);
+        connectionStateManager = new ConnectionStateManager(this, builder.getThreadFactory());
 
         byte[]      builderDefaultData = builder.getDefaultData();
         defaultData = (builderDefaultData != null) ? Arrays.copyOf(builderDefaultData, builderDefaultData.length) : new byte[0];

--- a/curator-framework/src/main/java/com/netflix/curator/framework/state/ConnectionStateManager.java
+++ b/curator-framework/src/main/java/com/netflix/curator/framework/state/ConnectionStateManager.java
@@ -31,6 +31,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -67,10 +68,10 @@ public class ConnectionStateManager implements Closeable
     /**
      * @param client the client
      */
-    public ConnectionStateManager(CuratorFramework client)
+    public ConnectionStateManager(CuratorFramework client, ThreadFactory threadFactory)
     {
         this.client = client;
-        service = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("ConnectionStateManager-%d").build());
+        service = Executors.newSingleThreadExecutor(threadFactory);
     }
 
     /**


### PR DESCRIPTION
This prevents different kind of threads being created by the CuratorFramework
and the ConnectionStateManager. In particular, if the user chose to supply
a daemon thread factory, the fact that ConnectionStateManager was using its
own thread factory would prevent JVM shutdown.
