### PR TITLE
Move TestNG to the top-level pom and define its scope as test.

### DIFF
--- a/curator-test/pom.xml
+++ b/curator-test/pom.xml
@@ -17,12 +17,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.1.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math</artifactId>
             <version>2.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,13 @@
             <artifactId>guava</artifactId>
             <version>10.0.1</version>
         </dependency>
+
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.1.1</version>
+            <scope>test</scope> 
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This ensures that unit tests will work and that packages that pull
in curator-test will not pull in TestNG as a dependency.

This fixes #20.
