### PR TITLE
Make ServiceCache close itself down properly.

### DIFF
--- a/curator-x-discovery/src/main/java/com/netflix/curator/x/discovery/details/ServiceCache.java
+++ b/curator-x-discovery/src/main/java/com/netflix/curator/x/discovery/details/ServiceCache.java
@@ -137,6 +137,9 @@ public class ServiceCache<T> implements Closeable, Listenable<ServiceCacheListen
             );
         listenerContainer.clear();
 
+        // Interrupt our own worker thread and shutdown thread pool
+        executorService.shutdownNow();
+
         discovery.cacheClosed(this);
     }
 


### PR DESCRIPTION
ServiceCache leaves a thread and an ExecutorService lying around even after its `close()` method has been called. This was causing me problems because it prevents the JVM from shutting down.

Commit message:

Fixed ServiceCache.close() to interrupt the cache's worker thread and
shut down its ExecutorService.

Note that the worker thread is interrupted _after_ all the listeners are
removed. So if the ZK watch triggers and the worker thread wakes up
while the cache is being closed, it may send a cacheChanged() event to
only some of the listeners.

Because of this, it may be better to interrupt the worker thread (and
make sure it's dead) _before_ removing the listeners.
