### PR TITLE
Speed up TestingServer startup time on OS X Lion.

### DIFF
--- a/curator-test/src/main/java/com/netflix/curator/test/InstanceSpec.java
+++ b/curator-test/src/main/java/com/netflix/curator/test/InstanceSpec.java
@@ -25,7 +25,7 @@ public class InstanceSpec
             // which could return the link-local address randomly, we'll manually resolve it and look for an address to
             // return that isn't link-local.  If for some reason we can't find an address that isn't link-local then
             // we'll fall back to the default lof just looking up 'localhost'.
-            for( InetAddress a : InetAddress.getAllByName("localhost") )
+            for ( InetAddress a : InetAddress.getAllByName("localhost") )
             {
               if ( !a.isLinkLocalAddress() )
               {


### PR DESCRIPTION
The comments in the source pretty clearly explain what's going on here.  I'm not sure why Lion exhibits this behavior, but it's 100% deterministic for me on several different machines.

One nice thing about this change is that it makes running tests faster (on Lion).  On my machine they dropped from 21 minutes to 14 minutes.
