### PR TITLE
Issue #98 JsonInstanceSerializer does not deserialize custom payload types

### DIFF
--- a/curator-x-discovery/src/main/java/com/netflix/curator/x/discovery/ServiceInstance.java
+++ b/curator-x-discovery/src/main/java/com/netflix/curator/x/discovery/ServiceInstance.java
@@ -24,6 +24,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+import org.codehaus.jackson.annotate.JsonTypeInfo.Id;
+
 /**
  * POJO that represents a service instance
  */
@@ -120,6 +123,7 @@ public class ServiceInstance<T>
         return sslPort;
     }
 
+    @JsonTypeInfo(use=Id.CLASS, defaultImpl=Object.class)
     public T getPayload()
     {
         return payload;

--- a/curator-x-discovery/src/test/java/com/netflix/curator/x/discovery/TestJsonInstanceSerializer.java
+++ b/curator-x-discovery/src/test/java/com/netflix/curator/x/discovery/TestJsonInstanceSerializer.java
@@ -18,6 +18,11 @@
 
 package com.netflix.curator.x.discovery;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.netflix.curator.x.discovery.details.JsonInstanceSerializer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -77,4 +82,85 @@ public class TestJsonInstanceSerializer
         Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
         Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
     }
+
+    @Test
+    public void		testPayloadAsList() throws Exception
+    {
+        JsonInstanceSerializer<Object>    serializer = new JsonInstanceSerializer<Object>(Object.class);
+        List<String> payload = new ArrayList<String>();
+        payload.add("Test value 1");
+        payload.add("Test value 2");
+        ServiceInstance<Object>           instance = new ServiceInstance<Object>("name", "id", "address", 10, 20, payload, 0, ServiceType.DYNAMIC, new UriSpec("{a}/b/{c}"));
+        byte[]                          bytes = serializer.serialize(instance);
+
+        ServiceInstance<Object>           rhs = serializer.deserialize(bytes);
+        Assert.assertEquals(instance, rhs);
+        Assert.assertEquals(instance.getId(), rhs.getId());
+        Assert.assertEquals(instance.getName(), rhs.getName());
+        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
+        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
+        Assert.assertEquals(instance.getPort(), rhs.getPort());
+        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
+        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+    }
+
+
+    @Test
+    public void		testPayloadAsMap() throws Exception
+    {
+        JsonInstanceSerializer<Object>    serializer = new JsonInstanceSerializer<Object>(Object.class);
+        Map<String,String> payload = new HashMap<String,String>();
+        payload.put("1", "Test value 1");
+        payload.put("2", "Test value 2");
+        ServiceInstance<Object>           instance = new ServiceInstance<Object>("name", "id", "address", 10, 20, payload, 0, ServiceType.DYNAMIC, new UriSpec("{a}/b/{c}"));
+        byte[]                          bytes = serializer.serialize(instance);
+
+        ServiceInstance<Object>           rhs = serializer.deserialize(bytes);
+        Assert.assertEquals(instance, rhs);
+        Assert.assertEquals(instance.getId(), rhs.getId());
+        Assert.assertEquals(instance.getName(), rhs.getName());
+        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
+        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
+        Assert.assertEquals(instance.getPort(), rhs.getPort());
+        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
+        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+    }
+
+    @Test
+    public void		testPayloadClass() throws Exception
+    {
+        JsonInstanceSerializer<Payload>    serializer = new JsonInstanceSerializer<Payload>(Payload.class);
+        Payload payload = new Payload();
+        payload.setVal("Test value");
+        ServiceInstance<Payload>           instance = new ServiceInstance<Payload>("name", "id", "address", 10, 20, payload, 0, ServiceType.DYNAMIC, new UriSpec("{a}/b/{c}"));
+        byte[]                          bytes = serializer.serialize(instance);
+
+        ServiceInstance<Payload>           rhs = serializer.deserialize(bytes);
+        Assert.assertEquals(instance, rhs);
+        Assert.assertEquals(instance.getId(), rhs.getId());
+        Assert.assertEquals(instance.getName(), rhs.getName());
+        Assert.assertEquals(instance.getPayload(), rhs.getPayload());
+        Assert.assertEquals(instance.getAddress(), rhs.getAddress());
+        Assert.assertEquals(instance.getPort(), rhs.getPort());
+        Assert.assertEquals(instance.getSslPort(), rhs.getSslPort());
+        Assert.assertEquals(instance.getUriSpec(), rhs.getUriSpec());
+    }
+
+    public static class Payload {
+    	private String val;
+    	public String getVal() {
+    		return val;
+    	}
+    	public void setVal(String val) {
+    		this.val = val;
+    	}
+    	@Override
+    	public boolean equals(Object other) {
+    		if (other == null || !(other instanceof Payload)) return false;
+    		String otherVal = ((Payload)other).getVal();
+			if (val == null) return val == otherVal;
+			return val.equals(otherVal);
+    	}
+    }
+
 }


### PR DESCRIPTION
Annotated getPayload() with @JsonTypeInfo.

Wrote a test for the new behavior and tests to verify that it still works for List and Map payloads.

There is, however, a breaking incompatibility with List payloads that will show up in environments that mix the old code and the new code.
- The new code will throw a JsonMappingException when it attempts to read a List payload written by the old code. 
- The old code, when it reads a List payload generated by the new code, will generate a list with two elements, the first of which is the class name of the List type, and the second of which is the original list.
