### PR TITLE
1.0.18

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,14 @@
-1.1.17/1.0.18 - August 2, 2012
-==============================
+1.1.17/1.0.18 - August 30, 2012
+===============================
 * Issue 132: If namespace is set in builder, getNamespace() does not return it
 
 * Issue 131: If connection is lost to the server, the ServiceInstance needs to re-register once
 there is a re-connection.
+
+* PathChildrenCache was not sending UPDATE messages when a node's data changed in the case
+that false was passed in the constructor for cacheData.
+
+* Merge 136 from wt: Add eclipse support to gradle.
 
 1.1.16/1.0.17 - August 2, 2012
 ==============================

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Establish version and status
 def performingRelease = project.hasProperty('release') && Boolean.parseBoolean(project.release)
-def releaseVersion = '1.0.17'
+def releaseVersion = '1.0.18'
 def versionPostfix = performingRelease?'':'-SNAPSHOT'
 version = "${releaseVersion}${versionPostfix}"
 status = performingRelease?'release':'snapshot'

--- a/curator-client/src/main/java/com/netflix/curator/ensemble/exhibitor/ExhibitorEnsembleProvider.java
+++ b/curator-client/src/main/java/com/netflix/curator/ensemble/exhibitor/ExhibitorEnsembleProvider.java
@@ -179,7 +179,7 @@ public class ExhibitorEnsembleProvider implements EnsembleProvider
             String newConnectionStringValue = newConnectionString.toString();
             if ( !newConnectionStringValue.equals(connectionString.get()) )
             {
-                log.info("Connection string has changed. Old value (%s), new value (%s)", connectionString.get(), newConnectionStringValue);
+                log.info(String.format("Connection string has changed. Old value (%s), new value (%s)", connectionString.get(), newConnectionStringValue));
             }
             Exhibitors newExhibitors = new Exhibitors
             (

--- a/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/cache/PathChildrenCache.java
@@ -487,7 +487,7 @@ public class PathChildrenCache implements Closeable
         }
         else
         {
-            client.checkExists().inBackground(existsCallback).forPath(fullPath);
+            client.checkExists().usingWatcher(dataWatcher).inBackground(existsCallback).forPath(fullPath);
         }
     }
 


### PR DESCRIPTION
- Issue 132: If namespace is set in builder, getNamespace() does not return it
- Issue 131: If connection is lost to the server, the ServiceInstance needs to re-register once
  there is a re-connection.
- PathChildrenCache was not sending UPDATE messages when a node's data changed in the case
  that false was passed in the constructor for cacheData.
- Merge 136 from wt: Add eclipse support to gradle.
