### PR TITLE
Fix namespace issue with FailedDeleteManager

### DIFF
--- a/curator-framework/src/main/java/com/netflix/curator/framework/imps/FailedDeleteManager.java
+++ b/curator-framework/src/main/java/com/netflix/curator/framework/imps/FailedDeleteManager.java
@@ -25,25 +25,27 @@ import org.slf4j.LoggerFactory;
 class FailedDeleteManager
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final CuratorFramework client;
+    private final CuratorFrameworkImpl client;
 
-    FailedDeleteManager(CuratorFramework client)
+    FailedDeleteManager(CuratorFrameworkImpl client)
     {
         this.client = client;
     }
 
-    void addFailedDelete(String path)
+    void addFailedDelete(String fixedPath)
     {
+        String unfixedPath = client.unfixForNamespace(fixedPath);
+
         if ( client.isStarted() )
         {
-            log.debug("Path being added to guaranteed delete set: " + path);
+            log.debug("Path being added to guaranteed delete set: " + fixedPath);
             try
             {
-                client.delete().guaranteed().inBackground().forPath(path);
+                client.delete().guaranteed().inBackground().forPath(unfixedPath);
             }
             catch ( Exception e )
             {
-                addFailedDelete(path);
+                addFailedDelete(fixedPath);
             }
         }
     }


### PR DESCRIPTION
Paths given to FailedDeleteManager are unfixed so when FailedDeleteManager resubmits the delete request it uses the CuratorFrameworkImpl's original namespace given in the builder instead of the namespace of the facade where the original delete().guarantee() request was made.
