### PR TITLE
Expose CuratorFramework#isClosed() state

### DIFF
--- a/curator-framework/src/main/java/com/netflix/curator/framework/CuratorFramework.java
+++ b/curator-framework/src/main/java/com/netflix/curator/framework/CuratorFramework.java
@@ -48,6 +48,13 @@ public interface CuratorFramework extends Closeable
     public boolean  isStarted();
 
     /**
+     * Return true if the client has been closed
+     *
+     * @return true/false
+     */
+    public boolean  isClosed();
+
+    /**
      * Start a create builder
      *
      * @return builder object

--- a/curator-framework/src/main/java/com/netflix/curator/framework/imps/CuratorFrameworkImpl.java
+++ b/curator-framework/src/main/java/com/netflix/curator/framework/imps/CuratorFrameworkImpl.java
@@ -184,6 +184,12 @@ public class CuratorFrameworkImpl implements CuratorFramework
     }
 
     @Override
+    public boolean isClosed()
+    {
+        return state.get() == State.STOPPED;
+    }
+
+    @Override
     public void     start()
     {
         log.info("Starting");


### PR DESCRIPTION
useful to check if a shared framework should be recreated when shared by multiple components
