### PR TITLE
Updates

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@
 * Issue 232: NodeCache wasn't handling server connection issues well. It would repeatedly execute checkExists()
 with a watcher causing the heap to fill with watcher objects.
 
+* Issue 233: An internal idiom being used to create an EnsurePath instance with the parent of a passed in path
+wasn't correct. Due to an unfortunate implementation of ZKPaths.PathAndNode (mea culpa) the root path is specified
+differently than non-root paths. To work around this, I added a method to EnsurePath - excludingLast() - that
+can be used instead of the idiom.
+
 1.2.6 - January 1, 2013
 =======================
 * Issue 214: Added rebuildNode method to PathChildrenCache.

--- a/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/atomic/DistributedAtomicValue.java
+++ b/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/atomic/DistributedAtomicValue.java
@@ -21,7 +21,6 @@ import com.netflix.curator.RetryPolicy;
 import com.netflix.curator.framework.CuratorFramework;
 import com.netflix.curator.framework.recipes.locks.InterProcessMutex;
 import com.netflix.curator.utils.EnsurePath;
-import com.netflix.curator.utils.ZKPaths;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import java.util.Arrays;
@@ -72,7 +71,7 @@ public class DistributedAtomicValue
         this.retryPolicy = retryPolicy;
         this.promotedToLock = promotedToLock;
         mutex = (promotedToLock != null) ? new InterProcessMutex(client, promotedToLock.getPath()) : null;
-        ensurePath = client.newNamespaceAwareEnsurePath(ZKPaths.getPathAndNode(path).getPath());
+        ensurePath = client.newNamespaceAwareEnsurePath(path).excludingLast();
     }
 
     /**

--- a/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/cache/NodeCache.java
+++ b/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/cache/NodeCache.java
@@ -28,7 +28,6 @@ import com.netflix.curator.framework.listen.ListenerContainer;
 import com.netflix.curator.framework.state.ConnectionState;
 import com.netflix.curator.framework.state.ConnectionStateListener;
 import com.netflix.curator.utils.EnsurePath;
-import com.netflix.curator.utils.ZKPaths;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.data.Stat;
@@ -130,7 +129,7 @@ public class NodeCache implements Closeable
         this.client = client;
         this.path = path;
         this.dataIsCompressed = dataIsCompressed;
-        ensurePath = client.newNamespaceAwareEnsurePath(ZKPaths.getPathAndNode(path).getPath());
+        ensurePath = client.newNamespaceAwareEnsurePath(path).excludingLast();
     }
 
     /**


### PR DESCRIPTION
... with the parent of a passed in path

wasn't correct. Due to an unfortunate implementation of ZKPaths.PathAndNode (mea culpa) the root path is specified
differently than non-root paths. To work around this, I added a method to EnsurePath - excludingLast() - that
can be used instead of the idiom.
