### PR TITLE
Fix performance issue with PathChildrenCache

### DIFF
--- a/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/cache/PathChildrenCache.java
+++ b/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/cache/PathChildrenCache.java
@@ -608,7 +608,7 @@ public class PathChildrenCache implements Closeable
 
     private void processChildren(List<String> children, RefreshMode mode) throws Exception
     {
-        List<String> fullPaths = Lists.transform
+        List<String> fullPaths = Lists.newArrayList(Lists.transform
         (
             children,
             new Function<String, String>()
@@ -619,7 +619,7 @@ public class PathChildrenCache implements Closeable
                     return ZKPaths.makePath(path, child);
                 }
             }
-        );
+        ));
         Set<String> removedNodes = Sets.newHashSet(currentData.keySet());
         removedNodes.removeAll(fullPaths);
 


### PR DESCRIPTION
I have a PathChildrenCache that is watching 30,000+ nodes.

The apply function inside processChildren consumes 100% CPU and is called hundreds of millions of times because transform is lazily evaluated and is used in a removeAll call.

Caching the list into a new array list is recommended by Guava and results in the apply function only be called once for each node.
