### PR TITLE
Fix create/delete race in LeaderLatch

### DIFF
--- a/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/leader/LeaderLatch.java
+++ b/curator-recipes/src/main/java/com/netflix/curator/framework/recipes/leader/LeaderLatch.java
@@ -332,7 +332,14 @@ public class LeaderLatch implements Closeable
                 if ( event.getResultCode() == KeeperException.Code.OK.intValue() )
                 {
                     setNode(event.getName());
-                    getChildren();
+                    if ( state.get() == State.CLOSED )
+                    {
+                        setNode(null);
+                    }
+                    else
+                    {
+                        getChildren();
+                    }
                 }
                 else
                 {

--- a/curator-recipes/src/test/java/com/netflix/curator/framework/recipes/leader/TestLeaderLatch.java
+++ b/curator-recipes/src/test/java/com/netflix/curator/framework/recipes/leader/TestLeaderLatch.java
@@ -73,6 +73,36 @@ public class TestLeaderLatch extends BaseClassForTests
     }
 
     @Test
+    public void testCreateDeleteRace() throws Exception
+    {
+        Timing timing = new Timing();
+        CuratorFramework client = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new RetryOneTime(1));
+        try
+        {
+            client.start();
+            LeaderLatch latch = new LeaderLatch(client, PATH_NAME);
+
+            latch.debugResetWaitLatch = new CountDownLatch(1);
+
+            latch.start();
+            latch.close();
+
+            timing.sleepABit();
+
+            latch.debugResetWaitLatch.countDown();
+
+            timing.sleepABit();
+
+            Assert.assertEquals(client.getChildren().forPath(PATH_NAME).size(), 0);
+
+        }
+        finally
+        {
+            Closeables.closeQuietly(client);
+        }
+    }
+
+    @Test
     public void testLostConnection() throws Exception
     {
         final int PARTICIPANT_QTY = 10;


### PR DESCRIPTION
There is a race between creating a node and deleting it that can result
in an orphaned latch.
